### PR TITLE
Fix values. Add resource section to provider.emulator

### DIFF
--- a/openstf/values.yaml
+++ b/openstf/values.yaml
@@ -106,9 +106,10 @@ provider:
         cpu: 2
         memory: 4096Mi
   emulator:
-    limits:
-      cpu: 500m
-      memory: 512Mi
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
 db:
   url: rethinkdb-rethinkdb-proxy.openstf
   port: 28015


### PR DESCRIPTION
There is `{{ toYaml $root.Values.provider.emulator.resources | indent 12 }}` substitution in emulators.yaml https://github.com/agoda-com/android-farm/blob/master/openstf/templates/emulators.yaml#L73
But `resource` section was not defined in values. So resolved value is `null`
I believe it's a typo in values file. 
Fixed it in this PR