### PR TITLE
Add deadline for pre-install job

### DIFF
--- a/openstf/templates/pre-install-job.yaml
+++ b/openstf/templates/pre-install-job.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  activeDeadlineSeconds: 300
   template:
     metadata:
       name: {{.Release.Name}}


### PR DESCRIPTION
according to [docs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) if pod fails Job will start a new pod.
So if config contains error (e.g. typo in rethinkdb URL) job will create infinite count of pods. 
In my case, it was 12k pods and broken cluster :)

In this PR I add deadline. The job doesn't create any new pods after deadline.
300 seconds seems reasonable for me. I beleive pre-install job finishes in 5 minutes in all cases. 
