### PR TITLE
Type ingress.annotations as a map

### DIFF
--- a/openstf/values.yaml
+++ b/openstf/values.yaml
@@ -141,7 +141,7 @@ dns:
 ingress:
   enabled: false
   # By default applies proper annotation for nginx ingress
-  annotations:
+  annotations: {}
   hostname: openstf.local
   ssl:
     enabled: false


### PR DESCRIPTION
Thanks for this awesome project!

By making annotations an empty map, it still clasified as empty in the if/else in ingress.yaml, but allows a user to add values using `--set`.
e.g.:
```bash
helm install --namespace openstf --name openstf \
    -f android-farm/openstf/values.yaml \
    --set \
ingress.annotations."nginx\.org/websocket-services"=openstf-openstf-nginx,\
ingress.annotations."nginx\.ingress\.kubernetes\.io/auth-type"=basic,\
ingress.annotations."nginx\.ingress\.kubernetes\.io/auth-secret"=basic-auth,\
ingress.annotations."nginx\.ingress\.kubernetes\.io/auth-realm"="Authentication Required - foo" \
    ./android-farm/openstf
```

Without the `{}`, helm fails to parse the `--set` values for `ingress.annotations`.